### PR TITLE
Prevent item labels from being added in town

### DIFF
--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -104,6 +104,7 @@ bool IsHighlightingLabelsEnabled()
 
 void AddItemToLabelQueue(int id, Point position)
 {
+	if ( leveltype == DTYPE_TOWN) return;
 	if (!IsHighlightingLabelsEnabled())
 		return;
 	Item &item = Items[id];
@@ -213,3 +214,4 @@ void DrawItemNameLabels(const Surface &out)
 }
 
 } // namespace devilution
+


### PR DESCRIPTION
Added a check to prevent adding item labels in town.